### PR TITLE
Receive typelize_from call even if Typelize is not enabled

### DIFF
--- a/lib/typelizer/dsl.rb
+++ b/lib/typelizer/dsl.rb
@@ -30,8 +30,6 @@ module Typelizer
 
       # save association of serializer to model
       def typelize_from(model)
-        return unless Typelizer.enabled?
-
         define_singleton_method(:_typelizer_model_name) { model }
       end
 


### PR DESCRIPTION
Otherwise, there can be a problem if a non-typelizer version of the Rails app boots up, and then (in the same process) we later try to run Typelize. In this case, the serializer class won't be re-parsed, so the main body of the `typelize_from` method won't ever have been called, making the attempted usage of `typelize_from` not have the intended effect.