### PR TITLE
Rescue ActiveRecord::NoDatabaseError

### DIFF
--- a/lib/typelizer/generator.rb
+++ b/lib/typelizer/generator.rb
@@ -22,6 +22,7 @@ module Typelizer
       writer.call(interfaces, force: force)
 
       interfaces
+    rescue ActiveRecord::NoDatabaseError
     end
 
     private


### PR DESCRIPTION
Otherwise, we can get into a chicken-and-egg situation when running `bin/rails db:create`. During the `bin/rails` application bootup process, Typelizer tries to access the ActiveRecord database, which will raise an error if the database doesn't yet exist. By rescuing that exception, we allow the `db:create` to complete successfully and create the database.