### PR TITLE
Rescue ActiveRecord::ConnectionNotEstablished

### DIFF
--- a/lib/typelizer/generator.rb
+++ b/lib/typelizer/generator.rb
@@ -22,7 +22,7 @@ module Typelizer
       writer.call(interfaces, force: force)
 
       interfaces
-    rescue ActiveRecord::NoDatabaseError
+    rescue ActiveRecord::ConnectionNotEstablished, ActiveRecord::NoDatabaseError
     end
 
     private


### PR DESCRIPTION
I think that this is necessary in order to be able to execute Rails commands when the database is not running (e.g. maybe when rolling out a Docker deployment from a cold start).