### PR TITLE
Check more safely whether object has typelizer_interface method

### DIFF
--- a/lib/typelizer/generator.rb
+++ b/lib/typelizer/generator.rb
@@ -44,7 +44,7 @@ module Typelizer
       files.each do |file|
         trace = TracePoint.new(:call) do |tp|
           begin
-            next unless tp.self.respond_to?(:typelizer_interface) && !tp.self.send(:respond_to_missing?, :typelizer_interface, false)
+            next unless tp.self.methods.include?(:typelizer_interface)
           rescue
             next
           end


### PR DESCRIPTION
This is copied from https://github.com/skryukov/typelizer/pull/ 4 .

This should cause fewer exceptions to be raised, which will be more performant.