### PR TITLE
Allow disabling via DISABLE_TYPELIZER env var

### DIFF
--- a/lib/typelizer.rb
+++ b/lib/typelizer.rb
@@ -21,7 +21,10 @@ require_relative "typelizer/railtie" if defined?(Rails)
 module Typelizer
   class << self
     def enabled?
-      %w[development test].include?(ENV["RAILS_ENV"]) || ENV["TYPELIZER"] == "true"
+      (
+        ENV["TYPELIZER"] == "true" ||
+          %w[development test].include?(ENV["RAILS_ENV"])
+      ) && !ENV.key?("DISABLE_TYPELIZER")
     end
 
     attr_accessor :dirs


### PR DESCRIPTION
This can be useful e.g. when running migrations to create a table that is already referenced in a serializer.

See https://github.com/davidrunger/dotfiles/commit/0bf0a5e8 .